### PR TITLE
Implement tile caching

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Leaflet.VectorTiles Test Page</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css"/>
-  <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet-src.js"></script>
   <script src="http://localhost:9966/dist/leaflet.vector-tiles.js"></script>
   <style>
     html, body, input { font-family: Helvetica; }

--- a/example/index.js
+++ b/example/index.js
@@ -15,7 +15,8 @@ function main(geojson) {
       lat: 0,
       lng: 0
     },
-    zoom: 2
+    zoom: 2,
+    preferCanvas: true,
   });
 
   //L.tileLayer('http://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);

--- a/example/vt_server.js
+++ b/example/vt_server.js
@@ -44,11 +44,14 @@ const pointTileIndex = geojsonvt(pointGeoj, {
 const emptyFeatCollection = featureCollection([]);
 
 app.get('/:z/:x/:y', (req, res) => {
+  if (req.get('If-Modified-Since')) {
+    return res.status(304).send();
+  }
   const [x, y, z] = [+req.params.x, +req.params.y, +req.params.z];
   const countries = countryTileIndex.getTile(z, x, y) || emptyFeatCollection;
   const points = pointTileIndex.getTile(z, x, y) || emptyFeatCollection;
   const buff = vtpbf.fromGeojsonVt({ countries, points });
-  res.send(buff);
+  res.status(200).send(buff);
 });
 
 app.get('/geojson/:type', (req, res) => {

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -1,0 +1,122 @@
+/**
+ * LRU cache for Tile objects
+ */
+
+
+/**
+ * Node object for tile cache linked list
+ *
+ * @class Node
+ * @private
+ */
+class Node {
+  constructor(data) {
+    self.data = data;
+    self.prev = null;
+    self.next = null;
+  }
+}
+
+
+/**
+ * This class implements an LRU cache
+ * Objects in the cache are stored by key in a hash table, hashed on `tileKey`
+ * A separate doubly linked list is used to maintain the order of eviction. By maintaining
+ * references to corresponding nodes in this._cache, we achieve constant time `get`s and `put`s.
+ *
+ * @class TileCache
+ * @private
+ */
+export default class TileCache {
+
+  /**
+   * Constructor
+   *
+   * @param {number} size - maximum number of items the cache can hold
+   * @param {boolean} [debug=false] - enables debug printing
+   */
+  constructor(size, debug = false) {
+    this._size = size;
+    this._debug = debug;
+    this._cache = {}; // a hashtable for holding cached items
+    this._head = null; // the head of a doubly linked list that maintains the order of items by age
+    this._tail = null // tail pointer to the order linked list
+  }
+
+  /**
+   * @param {string} tileKey
+   */
+  get(tileKey) {
+    if (!(tileKey in this._cache)) {
+      if (this._debug) {
+        console.log('tile cache:', 'miss', tileKey);
+      }
+      return null;
+    }
+
+    if (this._debug) {
+      console.log('tile cache', 'hit', tileKey);
+    }
+
+    // move node to front of linked list
+    const node = this._cache[tileKey].node;
+    if (node.prev) {
+      node.prev.next = node.next;
+    }
+    if (node === this._tail) {
+      this._tail = node.prev;
+    }
+    node.next = this._head;
+
+    return this._cache[tileKey].tile;
+  }
+
+  /**
+   * @param {string} tileKey
+   * @param {Tile} tile
+   */
+  put(tileKey, tile) {
+    if (this._debug) {
+      console.log('tile cache:', 'caching', tileKey);
+    }
+
+    if (tileKey in this._cache) {
+      // move to front of linked list
+      const node = this._cache[tileKey].node;
+      if (node.prev) {
+        node.prev.next = node.next;
+      }
+      node.next = this._head;
+      // the data may be new so always replace it
+      this._cache[tileKey].tile = tile;
+      return this;
+    }
+
+    // place at heaad of order linked list
+    let node = new Node({ tile, tileKey });
+    if (this._head) {
+      this._head.prev = node;
+    }
+    node.next = this._head;
+    this._head = node;
+
+    this._cache[tileKey] = { tileKey, tile, node };
+
+    if (Object.keys(this._cache) > this._size) {
+      // we need to evict an item
+
+      // remove from linked list
+      const tailNode = this._tail;
+      this._tail = tailNode.prev;
+      tailNode.prev.next = null;
+
+      // remove from cache table
+      const tailtileKey = tailNode.data.tileKey;
+      if (this._debug) {
+        console.log('tile cache:', 'evicting', tileKey);
+      }
+      delete this._cache[tailtileKey];
+    }
+  }
+}
+


### PR DESCRIPTION
This PR implements an [LRU cache](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_.28LRU.29) for tiles on the frontend. This feature requires that the tile server is able to return `304` statuses when the `If-Modified-Since` field of the HTTP request header is present.

_(it also includes some other clean up...sorry. need to do a better job of separating PRs out...)_