### PR TITLE
Implement setting cache size after initialization

### DIFF
--- a/Leaflet.VectorTiles.js
+++ b/Leaflet.VectorTiles.js
@@ -548,6 +548,17 @@ L.VectorTiles = L.GridLayer.extend({
   },
 
   /**
+   * Set the maximum size of the cache
+   *
+   * @param {number} size
+   * returns {L.VectorTiles} this
+   */
+  setTileCacheSize(size) {
+    this._tileCache.setSize(size);
+    return this;
+  },
+
+  /**
    * Convert a GeoJSON feature into a Leaflet feature
    * Point -> L.Circle
    * LineString -> L.Polyline

--- a/example/index.html
+++ b/example/index.html
@@ -18,6 +18,9 @@
   <div>
     search: <input id="search" type="text"/>
   </div>
+  <div>
+    set cache size: <input id="cache-size" type="text"/><button id="cache-size-button">set</button>
+  </div>
   <div id="map"></div>
   <script src="index.js"></script>
 </body>

--- a/example/index.html
+++ b/example/index.html
@@ -19,7 +19,10 @@
     search: <input id="search" type="text"/>
   </div>
   <div>
-    set cache size: <input id="cache-size" type="text"/><button id="cache-size-button">set</button>
+    <div>
+      set cache size: <input id="cache-size-input" type="range" min="0" max="150" value="50"/>
+    </div>
+    <div>cache size: <span id="cache-size">50</span></div>
   </div>
   <div id="map"></div>
   <script src="index.js"></script>

--- a/example/index.js
+++ b/example/index.js
@@ -65,7 +65,6 @@ function main(geojson) {
   };
 
   document.getElementById('cache-size-button').onclick = e => {
-    console.log(e);
     const size = +document.getElementById('cache-size').value;
     vtLayer.setTileCacheSize(size);
   };

--- a/example/index.js
+++ b/example/index.js
@@ -64,8 +64,9 @@ function main(geojson) {
       .forEach(id => vtLayer.setFeatureStyle(id, { color: 'black' }));
   };
 
-  document.getElementById('cache-size-button').onclick = e => {
-    const size = +document.getElementById('cache-size').value;
-    vtLayer.setTileCacheSize(size);
+  document.getElementById('cache-size-input').onchange = e => {
+    const cacheSize = +e.target.value;
+    document.getElementById('cache-size').innerHTML = cacheSize;
+    vtLayer.setTileCacheSize(cacheSize);
   };
 }

--- a/example/index.js
+++ b/example/index.js
@@ -63,4 +63,10 @@ function main(geojson) {
       .filter(c => c.indexOf(q) > -1)
       .forEach(id => vtLayer.setFeatureStyle(id, { color: 'black' }));
   };
+
+  document.getElementById('cache-size-button').onclick = e => {
+    console.log(e);
+    const size = +document.getElementById('cache-size').value;
+    vtLayer.setTileCacheSize(size);
+  };
 }

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -78,6 +78,7 @@ export default class TileCache {
   put(tileKey, tile) {
     if (this._debug) {
       console.log('tile cache:', 'caching', tileKey);
+      console.log(this._stringifyList());
     }
 
     if (tileKey in this._cache) {
@@ -114,6 +115,7 @@ export default class TileCache {
       const tailtileKey = tailNode.data.tileKey;
       if (this._debug) {
         console.log('tile cache:', 'evicting', tileKey);
+        console.log(this._stringifyList());
       }
       delete this._cache[tailtileKey];
     }
@@ -159,6 +161,7 @@ export default class TileCache {
       let { tileKey } = garbage.data;
       if (this._debug) {
         console.log('tile cache:', 'removing tile', tileKey, 'due to cache resize');
+        console.log(this._stringifyList());
       }
       delete this._cache[tileKey]; // delete from cache
       garbage = garbage.next;
@@ -166,6 +169,19 @@ export default class TileCache {
 
     // when this function exits, there should be no more references to the garbage
     // nodes in the linked list, so they will be garbage collected as usual
+  }
+
+  /**
+   *
+   */
+  _stringifyList() {
+    let node = this._head;
+    let out = '';
+    while (node !== null) {
+      out += `(${node.data.tileKey}) -> `;
+      node = node.next;
+    }
+    return out;
   }
 }
 

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -44,7 +44,10 @@ export default class TileCache {
   }
 
   /**
+   * Retrieve an item from the cache
+   *
    * @param {string} tileKey
+   * @returns {Tile|null}
    */
   get(tileKey) {
     if (!(tileKey in this._cache)) {
@@ -139,6 +142,8 @@ export default class TileCache {
       return;
     }
 
+    this._size = size;
+
     if (this._head == null) {
       // this cache is empty
       return;
@@ -172,7 +177,10 @@ export default class TileCache {
   }
 
   /**
+   * Returns a string reprenting the current order of tiles in the cache
    *
+   * @returns {string}
+   * @private
    */
   _stringifyList() {
     let node = this._head;

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -178,7 +178,7 @@ export default class TileCache {
     let node = this._head;
     let out = '';
     while (node !== null) {
-      out += `(${node.data.tileKey}) -> `;
+      out += `(coords = ${node.data.tileKey}, feature count = ${Object.keys(this._cache[node.data.tileKey].tile._features).length}) -> `;
       node = node.next;
     }
     return out;

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -11,9 +11,9 @@
  */
 class Node {
   constructor(data) {
-    self.data = data;
-    self.prev = null;
-    self.next = null;
+    this.data = data;
+    this.prev = null;
+    this.next = null;
   }
 }
 
@@ -127,6 +127,10 @@ export default class TileCache {
       throw "Size cannot be a negative number";
     }
 
+    if (this._debug) {
+      console.log('tile cache:', 'changing cache size from', this._size, 'to', size);
+    }
+
     if (size >= this._size) {
       // we are increasing the size, no need to remove items from the cache
       this._size = size;
@@ -152,7 +156,11 @@ export default class TileCache {
 
     // collect the garbage
     while (garbage != null) {
-      delete this._cache[garbage.data.tileKey]; // delete from cache
+      let { tileKey } = garbage.data;
+      if (this._debug) {
+        console.log('tile cache:', 'removing tile', tileKey, 'due to cache resize');
+      }
+      delete this._cache[tileKey]; // delete from cache
       garbage = garbage.next;
     }
 

--- a/tile_cache.js
+++ b/tile_cache.js
@@ -93,7 +93,7 @@ export default class TileCache {
     }
 
     // place at heaad of order linked list
-    let node = new Node({ tile, tileKey });
+    let node = new Node({ tileKey });
     if (this._head) {
       this._head.prev = node;
     }
@@ -117,6 +117,47 @@ export default class TileCache {
       }
       delete this._cache[tailtileKey];
     }
+  }
+
+  /**
+   * @param {number} size
+   */
+  setSize(size) {
+    if (size < 0) {
+      throw "Size cannot be a negative number";
+    }
+
+    if (size >= this._size) {
+      // we are increasing the size, no need to remove items from the cache
+      this._size = size;
+      return;
+    }
+
+    if (this._head == null) {
+      // this cache is empty
+      return;
+    }
+
+    let node = this._head;
+    let garbage = node;
+    if (size > 0) {
+      let c = 1;
+      while (c < size && node.next != null) {
+        node = node.next;
+        c++;
+      }
+      garbage = node.next;
+      node.next = null;
+    }
+
+    // collect the garbage
+    while (garbage != null) {
+      delete this._cache[garbage.data.tileKey]; // delete from cache
+      garbage = garbage.next;
+    }
+
+    // when this function exits, there should be no more references to the garbage
+    // nodes in the linked list, so they will be garbage collected as usual
   }
 }
 


### PR DESCRIPTION
Adds support for changing the cache size after the library has been instantiated. 

Possible use case is allowing user to dynamically select how much memory they want their maps using at runtime.